### PR TITLE
feat: define shape generic

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -13,7 +13,7 @@ assert_tensor_constant <- function(
   if (!inherits(x@value, TensorConstant)) {
     cli::cli_abort("tnsr must be a TensorConstant")
   }
-  if (!is.null(ndims) && length(dim(x@value)) != ndims) {
+  if (!is.null(ndims) && length(shape(x@value)) != ndims) {
     cli::cli_abort("tnsr must have {ndims} dimensions")
   }
 

--- a/R/constant.R
+++ b/R/constant.R
@@ -28,7 +28,7 @@ method(repr, TensorConstant) <- function(x, simplify_dense = TRUE) {
     tolower(as.logical(data))
   }
 
-  if (simplify_dense && length(dim(data)) <= 1L) {
+  if (simplify_dense && length(shape(data)) <= 1L) {
     return(paste0(
       "array<",
       repr(type@elt_type),
@@ -46,10 +46,10 @@ method(repr, TensorConstant) <- function(x, simplify_dense = TRUE) {
       repr(type)
     ))
   }
-  dim(value_reprs) <- dim(data)
+  dim(value_reprs) <- shape(data)
 
   f <- function(x) {
-    if (length(dim(x)) == 1L || is.vector(x)) {
+    if (length(shape(x)) == 1L || is.vector(x)) {
       paste0("[", paste(x, collapse = ", "), "]")
     } else {
       paste0("[", paste(apply(x, 1, f), collapse = ", "), "]")
@@ -94,7 +94,7 @@ method(r_to_constant, S7::class_logical) <- function(
     stop("Invalid elt_type for logical")
   }
   shape <- Shape(
-    if (is.array(value)) dim(value) else integer()
+    if (is.array(value)) shape(value) else integer()
   )
 
   stablehlo_type <- BooleanType()
@@ -127,7 +127,7 @@ method(r_to_constant, S7::class_double) <- function(
   }
 
   shape <- Shape(
-    if (is.array(value)) dim(value) else integer()
+    if (is.array(value)) shape(value) else integer()
   )
 
   element_type_obj <- TensorElementType(type = elt_type)
@@ -160,7 +160,7 @@ method(r_to_constant, S7::class_integer) <- function(
   }
 
   shape <- Shape(
-    if (is.array(value)) dim(value) else integer()
+    if (is.array(value)) shape(value) else integer()
   )
 
   element_type_obj <- TensorElementType(type = elt_type)

--- a/R/func_variable.R
+++ b/R/func_variable.R
@@ -197,5 +197,5 @@ method(c, FuncVariable) <- function(...) {
 }
 
 method(dim, FuncVariable) <- function(x) {
-  dim(x@value_type@shape@dims)
+  shape(x@value_type@shape@dims)
 }

--- a/R/op-broadcast_in_dim.R
+++ b/R/op-broadcast_in_dim.R
@@ -11,7 +11,7 @@ infer_types_broadcast_in_dim <- function(
   stopifnot(inherits(operand@type, TensorType))
 
   # Extract operand dims and target result dims
-  operand_dims <- dim(operand)
+  operand_dims <- shape(operand)
   result_dims <- as.integer(shape_out)
 
   bdims <- broadcast_dimensions@value@data
@@ -37,7 +37,7 @@ infer_types_broadcast_in_dim <- function(
   }
 
   # (C5) For all d in axes(operand):
-  #   dim(operand, d) = 1 OR dim(operand, d) = dim(result, broadcast_dimensions[d])
+  #   shape(operand, d) = 1 OR shape(operand, d) = shape(result, broadcast_dimensions[d])
   for (d in seq_along(operand_dims)) {
     op_dim <- operand_dims[d]
     res_dim <- result_dims[bdims[d] + 1L] # 0-based to 1-based

--- a/R/op-dot_general.R
+++ b/R/op-dot_general.R
@@ -8,8 +8,8 @@ infer_types_dot_general <- function(
   stopifnot(inherits(lhs@type, TensorType))
   stopifnot(inherits(rhs@type, TensorType))
   stopifnot(lhs@type@elt_type == rhs@type@elt_type)
-  dim_lhs <- dim(lhs)
-  dim_rhs <- dim(rhs)
+  dim_lhs <- shape(lhs)
+  dim_rhs <- shape(rhs)
   contracting_dims <- dot_dimension_numbers@contracting_dims
   batching_dims <- dot_dimension_numbers@batching_dims
 

--- a/R/shape.R
+++ b/R/shape.R
@@ -6,9 +6,18 @@ Shape <- new_class(
   properties = list(
     dims = S7::class_numeric
   ),
+  constructor = function(dims) {
+    new_object(
+      S7::S7_object(),
+      dims = as.integer(dims)
+    )
+  },
   validator = function(self) {
-    stopifnot(isTRUE(all.equal(self@dims, as.integer(self@dims))))
-    dims = as.integer(self@dims)
+    if (!is.integer(self@dims)) {
+      stop("dims must be an integer vector")
+    }
+
+    dims = self@dims
     if (any(dims[!is.na(dims)] < 0L)) {
       stop("Dimensions must be >= 0")
     }
@@ -23,4 +32,20 @@ method(repr, Shape) <- function(x) {
   dims = x@dims
   dims[is.na(dims)] = "?"
   paste0(dims, collapse = "x")
+}
+
+shape <- new_generic(
+  "shape",
+  "x",
+  function(x, ...) {
+    S7::S7_dispatch()
+  }
+)
+
+method(shape, Shape) <- function(x) {
+  x@dims
+}
+
+method(shape, S7::class_any) <- function(x) {
+  dim(x)
 }

--- a/R/types.R
+++ b/R/types.R
@@ -137,7 +137,7 @@ ValueType <- new_class(
 
 
 method(dim, ValueType) <- function(x) {
-  dim(x@type)
+  shape(x@type)
 }
 
 method(dim, TensorType) <- function(x) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -80,11 +80,11 @@ capitalize = function(str) {
 }
 
 get_dims <- function(data) {
-  if (is.null(dim(data))) {
+  if (is.null(shape(data))) {
     if (length(data) == 1) {
       return(1L)
     }
     return(length(data))
   }
-  dim(data)
+  shape(data)
 }

--- a/tests/testthat/test-shape.R
+++ b/tests/testthat/test-shape.R
@@ -1,4 +1,7 @@
-test_that("Shape Repr", {
+test_that("shape", {
   shape <- Shape(c(1, 2, NA))
   expect_equal(repr(shape), "1x2x?")
+  shape <- Shape(c(1, 2))
+  expect_equal(shape(shape), c(1, 2))
+  expect_integer(shape(shape))
 })


### PR DESCRIPTION
`dim()` in R has some restrictions; for example, it cannot be `integer()` for "scalar" tensors.
I expect some issues when we define `dim()` in a way that returns `integer()`, so we define our own `shape()` generic to make this distinction clear.