### PR TITLE
release: stablehlo 0.2.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: stablehlo
 Title: Write stableHLO programs
-Version: 0.1.0.9000
+Version: 0.2.0
 Authors@R: c(
     person("Daniel", "Falbel", , "daniel@posit.co", role = "aut",
            comment = c(ORCID = "https://orcid.org/0009-0006-0143-2392")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,18 +21,14 @@ Imports:
     cli,
     methods,
     rlang,
-    tengen (>= 0.1.0),
+    tengen (>= 0.2.0),
     withr,
-    xlamisc
+    xlamisc (>= 0.2.0)
 Suggests:
     rmarkdown,
     knitr,
-    pjrt (>= 0.1.0),
+    pjrt (>= 0.2.0),
     testthat (>= 3.0.0)
-Remotes:
-    r-xla/pjrt,
-    r-xla/tengen,
-    r-xla/xlamisc
 Additional_repositories:
     https://r-xla.r-universe.dev
 Config/build/compilation-database: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,8 +11,6 @@
 
 ## Miscellaneous
 
-* Simplify the generated stablehlo lines for ops without
-  attributes where all input and output value types are identical.
 * Use a simpler StableHLO string format for improved readability
 
 # stablehlo 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# stablehlo (development version)
+# stablehlo 0.2.0
 
 ## Features
 
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 * Constants +-Inf/NaN of dtype f64 are now correctly created.
+* Fixed assembly format for `select` op with all boolean (i1) types.
 
 ## Miscellaneous
 


### PR DESCRIPTION
## Summary

Release stablehlo 0.2.0.

## Changes

### Features

* Added support for Modules

### Bug fixes

* Constants +-Inf/NaN of dtype f64 are now correctly created.
* Fixed assembly format for `select` op with all boolean (i1) types.

### Miscellaneous

* Use a simpler StableHLO string format for improved readability