### PR TITLE
fix: hlo_reduce_window now works on rank-1 inputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,12 +13,7 @@
 
 ## Bug fixes
 
-* `hlo_reduce_window()` now works on rank-1 inputs. The wrapper was passing
-  `shape = c()` for the four window-attribute constants, which caused
-  length-1 vectors to be encoded as 0-D scalars and violated the StableHLO
-  spec (which requires 1-D `si64` tensors per (I3)–(I6)). The shape is now
-  set explicitly from the value length.
-
+`hlo_reduce_window()` now works on rank-1 inputs.
 # stablehlo 0.2.0
 
 ## Features

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,14 @@
 * `OpName()` and `new_Op()` gain a `dialect` argument (default `"stablehlo"`)
   to support ops from other MLIR dialects.
 
+## Bug fixes
+
+* `hlo_reduce_window()` now works on rank-1 inputs. The wrapper was passing
+  `shape = c()` for the four window-attribute constants, which caused
+  length-1 vectors to be encoded as 0-D scalars and violated the StableHLO
+  spec (which requires 1-D `si64` tensors per (I3)–(I6)). The shape is now
+  set explicitly from the value length.
+
 # stablehlo 0.2.0
 
 ## Features

--- a/R/op-reduce_window.R
+++ b/R/op-reduce_window.R
@@ -241,31 +241,20 @@ hlo_reduce_window <- function(
   inputs <- ensure_func_vals(inputs)
   init_values <- ensure_func_vals(init_values)
 
+  # Per spec, window_dimensions / window_strides / base_dilations /
+  # window_dilations are 1-D si64 tensors. Pass `shape = length(value)`
+  # explicitly so length-1 inputs (rank-1 reduce_window) become 1-D
+  # length-1 instead of falling through `constant_attr`'s default that
+  # treats single-element vectors as 0-D scalars.
+  one_d <- function(name, value) {
+    value <- as.integer(value)
+    constant_attr(name, value, dtype = "i64", shape = length(value))
+  }
   attrs <- list(
-    constant_attr(
-      "window_dimensions",
-      as.integer(window_dimensions),
-      dtype = "i64",
-      shape = c()
-    ),
-    constant_attr(
-      "window_strides",
-      as.integer(window_strides),
-      dtype = "i64",
-      shape = c()
-    ),
-    constant_attr(
-      "base_dilations",
-      as.integer(base_dilations),
-      dtype = "i64",
-      shape = c()
-    ),
-    constant_attr(
-      "window_dilations",
-      as.integer(window_dilations),
-      dtype = "i64",
-      shape = c()
-    ),
+    one_d("window_dimensions", window_dimensions),
+    one_d("window_strides", window_strides),
+    one_d("base_dilations", base_dilations),
+    one_d("window_dilations", window_dilations),
     constant_attr(
       "padding",
       `storage.mode<-`(padding, "integer"),

--- a/tests/testthat/test-op-reduce_window.R
+++ b/tests/testthat/test-op-reduce_window.R
@@ -61,6 +61,42 @@ test_that("basic reduce_window (sum pooling)", {
   expect_equal(out, expected, tolerance = 1e-5)
 })
 
+test_that("rank-1 reduce_window (sum pooling)", {
+  func <- local_func()
+
+  x <- hlo_input("x", "f32", shape = 6L)
+  init <- hlo_scalar(0, dtype = "f32")
+
+  red <- local_func("reducer")
+  a <- hlo_input("a", "f32")
+  b <- hlo_input("b", "f32")
+  red <- hlo_return(hlo_add(a, b))
+
+  r <- hlo_reduce_window(
+    inputs = x,
+    init_values = init,
+    window_dimensions = 2L,
+    window_strides = 2L,
+    base_dilations = 1L,
+    window_dilations = 1L,
+    padding = matrix(0L, nrow = 1L, ncol = 2L),
+    body = red
+  )
+  func <- hlo_return(r)
+
+  skip_if_not_installed("pjrt")
+
+  program <- pjrt_program(repr(func))
+  executable <- pjrt_compile(program)
+
+  data <- as.numeric(1:6)
+  x_buf <- pjrt_buffer(data, dtype = "f32")
+  out_buf <- pjrt_execute(executable, x_buf)
+  out <- as_array(out_buf)
+
+  expect_equal(out, array(c(3, 7, 11), dim = 3L), tolerance = 1e-5)
+})
+
 test_that("errors", {
   body <- local_func("body")
   x <- hlo_input("x", "f32")


### PR DESCRIPTION
## Summary

`hlo_reduce_window()` was broken on rank-1 inputs. The wrapper passed `shape = c()` for `window_dimensions`, `window_strides`, `base_dilations`, and `window_dilations`. With `shape = NULL`, `constant_attr()` falls back to its heuristic:

```r
if (is.null(shape)) {
  shape <- if (length(value) == 1L) integer() else length(value)
}
```

For length-1 inputs that produces a 0-D scalar — but [SPEC.md](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#reduce_window) (I3)–(I6) says these must be **1-D** `si64` tensor constants of length equal to input rank. The length-≥2 case happened to work because `length(value)` (1-D) and `length(value)` (the heuristic) coincide.

## Fix

Set the shape explicitly from the value length on each call. Length-1 vectors now become 1-D length-1 tensors, satisfying the spec. No need for any rank-1-to-rank-2 lifting hack.

## Test plan

- [x] Regression test added: sum-pool `1:6` with window 2, stride 2 → `array(c(3, 7, 11), dim = 3L)`.
- [x] Existing rank-2 reduce_window test still passes (snapshot unchanged — for length-2 vectors the explicit shape and the heuristic give the same result).
- [x] Full `testthat::test_local()` is green.
- [ ] CI green.

This was originally bundled into #158, but the workaround there (lift rank-1 inputs to rank-2 around the call) was masking the real bug. Splitting it off so the fix lands cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)