### PR TITLE
fix(constant): emit width-correct hex for f64 NaN/Inf constants

### DIFF
--- a/R/format_double.R
+++ b/R/format_double.R
@@ -33,13 +33,26 @@ format_double <- function(x, precision = 64) {
   infs <- is.infinite(x)
   finite_mask <- !nans & !infs
 
-  res[nans] <- "0x7FC00000"
+  # IEEE-754 bit patterns for non-finite values, at the requested width. These
+  # must match the tensor's element width: reusing the 32-bit patterns for an
+  # f64 constant makes it parse as a tiny denormal (~1e-314), not NaN/Inf.
+  if (precision == 32) {
+    nan_hex <- "0x7FC00000"
+    pos_inf_hex <- "0x7F800000"
+    neg_inf_hex <- "0xFF800000"
+  } else {
+    nan_hex <- "0x7FF8000000000000"
+    pos_inf_hex <- "0x7FF0000000000000"
+    neg_inf_hex <- "0xFFF0000000000000"
+  }
+
+  res[nans] <- nan_hex
 
   if (any(infs)) {
     pos_inf <- infs & (x > 0)
     neg_inf <- infs & (x < 0)
-    res[pos_inf] <- "0x7F800000"
-    res[neg_inf] <- "0xFF800000"
+    res[pos_inf] <- pos_inf_hex
+    res[neg_inf] <- neg_inf_hex
   }
 
   if (any(finite_mask)) {

--- a/tests/testthat/test-format_double.R
+++ b/tests/testthat/test-format_double.R
@@ -1,0 +1,23 @@
+test_that("format_double emits 32-bit hex bit-patterns for non-finite values", {
+  expect_equal(format_double(NaN, 32), "0x7FC00000")
+  expect_equal(format_double(Inf, 32), "0x7F800000")
+  expect_equal(format_double(-Inf, 32), "0xFF800000")
+})
+
+test_that("format_double emits width-correct 64-bit hex bit-patterns for non-finite values", {
+  # Previously these wrongly reused the 32-bit patterns, so an f64 NaN/Inf
+  # constant was parsed as a tiny denormal (~1e-314) instead of NaN/Inf.
+  expect_equal(format_double(NaN, 64), "0x7FF8000000000000")
+  expect_equal(format_double(Inf, 64), "0x7FF0000000000000")
+  expect_equal(format_double(-Inf, 64), "0xFFF0000000000000")
+})
+
+test_that("format_double keeps non-finite positions in a mixed vector", {
+  out32 <- format_double(c(1, NaN, Inf, -Inf), 32)
+  expect_equal(out32[2:4], c("0x7FC00000", "0x7F800000", "0xFF800000"))
+  expect_match(out32[1], "^1")
+
+  out64 <- format_double(c(1, NaN, Inf, -Inf), 64)
+  expect_equal(out64[2:4], c("0x7FF8000000000000", "0x7FF0000000000000", "0xFFF0000000000000"))
+  expect_match(out64[1], "^1")
+})

--- a/tests/testthat/test-format_double.R
+++ b/tests/testthat/test-format_double.R
@@ -18,6 +18,9 @@ test_that("format_double keeps non-finite positions in a mixed vector", {
   expect_match(out32[1], "^1")
 
   out64 <- format_double(c(1, NaN, Inf, -Inf), 64)
-  expect_equal(out64[2:4], c("0x7FF8000000000000", "0x7FF0000000000000", "0xFFF0000000000000"))
+  expect_equal(
+    out64[2:4],
+    c("0x7FF8000000000000", "0x7FF0000000000000", "0xFFF0000000000000")
+  )
   expect_match(out64[1], "^1")
 })

--- a/tests/testthat/test-op-constant.R
+++ b/tests/testthat/test-op-constant.R
@@ -177,18 +177,35 @@ test_that("can use dtype with constant", {
   expect_snapshot(hlo_scalar(FALSE, BooleanType()))
 })
 
-test_that("nan, inf, -inf", {
+test_that("nan, inf, -inf scalars execute correctly for f32 and f64", {
+  skip_if_not_installed("pjrt")
+  # f64 previously reused the 32-bit hex bit-patterns, so the constants were
+  # parsed as tiny denormals (~1e-314) instead of Inf/-Inf/NaN at runtime.
+  for (dt in c("f32", "f64")) {
+    local_func()
+    x1 <- hlo_scalar(Inf, dtype = dt)
+    x2 <- hlo_scalar(-Inf, dtype = dt)
+    x3 <- hlo_scalar(NaN, dtype = dt)
+    f <- hlo_return(x1, x2, x3)
+    exec <- pjrt_compile(pjrt_program(repr(f)))
+    outs <- lapply(pjrt_execute(exec), as_array)
+    expect_equal(outs[[1]], Inf, info = dt)
+    expect_equal(outs[[2]], -Inf, info = dt)
+    expect_true(is.nan(outs[[3]]), info = dt)
+  }
+})
+
+test_that("nan, inf, -inf in an f64 tensor execute correctly", {
   skip_if_not_installed("pjrt")
   local_func()
-  x1 <- hlo_scalar(Inf, dtype = "f32")
-  x2 <- hlo_scalar(-Inf, dtype = "f32")
-  x3 <- hlo_scalar(NaN, dtype = "f32")
-  f <- hlo_return(x1, x2, x3)
+  x <- hlo_tensor(c(1, NaN, Inf, -Inf), dtype = "f64")
+  f <- hlo_return(x)
   exec <- pjrt_compile(pjrt_program(repr(f)))
-  outs <- lapply(pjrt_execute(exec), as_array)
-  expect_equal(outs[[1]], Inf)
-  expect_equal(outs[[2]], -Inf)
-  expect_equal(outs[[3]], NaN)
+  out <- as_array(pjrt_execute(exec))
+  expect_equal(out[1], 1)
+  expect_true(is.nan(out[2]))
+  expect_equal(out[3], Inf)
+  expect_equal(out[4], -Inf)
 })
 
 test_that("Efficient representation of constants with single value", {


### PR DESCRIPTION
`format_double()` hardcoded the 32-bit IEEE-754 bit-patterns for NaN, +Inf and -Inf regardless of `precision`, so an f64 non-finite constant was emitted as `dense<0x7FC00000> : tensor<f64>`. A 32-bit pattern in a 64-bit tensor parses as a tiny denormal (~1e-314), i.e. the constant silently became garbage (and 0 once downcast to f32).

Select the bit-patterns by precision:
  NaN  -> 0x7FF8000000000000
  +Inf -> 0x7FF0000000000000
  -Inf -> 0xFFF0000000000000

Add unit tests for `format_double` and extend the pjrt execution test in test-op-constant to cover f64 NaN/Inf scalars and an f64 tensor.