### PR TITLE
perf: drop force(arg) in value-type asserts

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -91,7 +91,6 @@ assert_vt_is_tensor <- function(
   arg = rlang::caller_arg(x),
   call = rlang::caller_env()
 ) {
-  force(arg)
   if (!test_class(x, "ValueType")) {
     cli_abort(
       c(
@@ -122,7 +121,6 @@ assert_vt_has_ttype <- function(
   call = rlang::caller_env()
 ) {
   dtypes <- list(...)
-  force(arg)
 
   if (!test_class(x, "ValueType")) {
     cli_abort(


### PR DESCRIPTION
assert_vt_is_tensor() / assert_vt_has_ttype() called force(arg), eagerly evaluating the lazy rlang::caller_arg(x) default (which deparses the call) on every successful op. caller_arg stays lazy without it and is still evaluated by cli_abort on failure, so error messages are unchanged.