### PR TITLE
perf: store the op buffer in a fastmap::fastqueue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,12 @@ The builder is optimized for low per-op overhead (lowering a graph should stay
 in the same order of magnitude as `pjrt_compile()`):
 
 * **Lazy rendering**: each op is stored on its func as a deferred
-  `list(render, ctx)` pair via `func_emit()` (a cons list, so appending is
-  O(1) per op and never touches earlier ops). The MLIR text line is produced
-  by `render(ctx)` at `repr()` time, in `func_lines()`, front-to-back. There
+  `list(render, ctx)` pair via `func_emit()`, appended to a growable `ops`
+  list held in the func's `buf` environment. Because `ops` is not aliased
+  between emissions, `buf$ops[[n]] <- item` extends it in place with
+  amortised-O(1) doubling, so appending stays cheap and never rebuilds earlier
+  entries. The MLIR text line is produced by `render(ctx)` at `repr()` time, in
+  `func_lines()`, front-to-back (the buffer is already in emission order). There
   is no op-record tree to walk; a single `repr()` per program means deferring
   the render costs nothing over rendering eagerly.
 * **Repr-time value ids**: an auto SSA id (`ValueId()`) carries a mutable cell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,14 +11,15 @@ The builder is optimized for low per-op overhead (lowering a graph should stay
 in the same order of magnitude as `pjrt_compile()`):
 
 * **Lazy rendering**: each op is stored on its func as a deferred
-  `list(render, ctx)` pair via `func_emit()`, appended to a growable `ops`
-  list held in the func's `buf` environment. Because `ops` is not aliased
-  between emissions, `buf$ops[[n]] <- item` extends it in place with
-  amortised-O(1) doubling, so appending stays cheap and never rebuilds earlier
-  entries. The MLIR text line is produced by `render(ctx)` at `repr()` time, in
-  `func_lines()`, front-to-back (the buffer is already in emission order). There
-  is no op-record tree to walk; a single `repr()` per program means deferring
-  the render costs nothing over rendering eagerly.
+  `list(render, ctx)` pair via `func_emit()`, appended to the func's `buf`
+  (a `fastmap::fastqueue`). The queue gives amortised-O(1) append that never
+  copies earlier ops — note that growing an ordinary R list held in a field
+  (`buf$ops[[n]] <- item`) is *not* O(1): the list is copy-on-modify and gets
+  duplicated on every append, so it degrades to O(n^2). The MLIR text line is
+  produced by `render(ctx)` at `repr()` time, in `func_lines()`, front-to-back
+  (`buf$as_list()` yields ops in emission order). There is no op-record tree to
+  walk; a single `repr()` per program means deferring the render costs nothing
+  over rendering eagerly.
 * **Repr-time value ids**: an auto SSA id (`ValueId()`) carries a mutable cell
   and gets its number when first rendered — in appearance order (`%0`, `%1`,
   ...), sharing one counter per program installed by `repr.Func`. Numbering

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,7 @@ BugReports: https://github.com/r-xla/stablehlo/issues
 Imports:
     checkmate,
     cli,
+    fastmap,
     methods,
     rlang,
     tengen (>= 0.2.0),

--- a/R/func.R
+++ b/R/func.R
@@ -136,14 +136,11 @@ repr.FuncId <- function(x, ...) {
 
 # Append a deferred op to the func's buffer. Each op is stored as a
 # `list(render, payload)` pair; the line is produced by `render(payload)` at
-# repr time (see func_lines()), once value ids can be numbered. `ops` is grown
-# in place: because it lives in the `buf` environment and is not aliased between
-# emissions, `[[<-` extends it with amortised-O(1) doubling rather than copying.
+# repr time (see func_lines()), once value ids can be numbered. The buffer is a
+# `fastmap::fastqueue`, giving amortised-O(1) append that never copies earlier
+# ops (unlike growing an R list held in a field, which is copy-on-modify).
 func_emit <- function(func, item) {
-  buf <- func[["buf"]]
-  n <- buf$n + 1L
-  buf$n <- n
-  buf$ops[[n]] <- item
+  func[["buf"]]$add(item)
 }
 
 # Rendered op lines of a Func, in emission order (`character()`). Rendering
@@ -157,13 +154,12 @@ func_lines <- function(func) {
     push_repr_ids(collect_named_numeric(func))
     on.exit(pop_repr_ids(NULL), add = TRUE)
   }
-  buf <- func[["buf"]]
-  ops <- buf$ops
-  n <- buf$n
-  # `ops` is already in emission order (front-to-back).
+  # `as_list()` returns ops in insertion (emission) order.
+  items <- func[["buf"]]$as_list()
+  n <- length(items)
   lines <- character(n)
   for (i in seq_len(n)) {
-    item <- ops[[i]]
+    item <- items[[i]]
     lines[[i]] <- item[[1L]](item[[2L]])
   }
   lines
@@ -181,9 +177,8 @@ collect_named_numeric <- function(func) {
       out <- c(out, as.numeric(id))
     }
   }
-  buf <- func[["buf"]]
-  for (i in seq_len(buf$n)) {
-    for (cf in buf$ops[[i]][[2L]]$funcs) {
+  for (item in func[["buf"]]$as_list()) {
+    for (cf in item[[2L]]$funcs) {
       out <- c(out, collect_named_numeric(cf))
     }
   }
@@ -284,10 +279,7 @@ Func <- function(
   env$id <- id
   env$inputs <- inputs
   env$outputs <- outputs
-  buf <- new.env(parent = emptyenv())
-  buf$n <- 0L
-  buf$ops <- list()
-  env$buf <- buf
+  env$buf <- fastmap::fastqueue()
 
   # Return the environment directly with Func class
   class(env) <- c("Func", "environment")

--- a/R/func.R
+++ b/R/func.R
@@ -136,12 +136,14 @@ repr.FuncId <- function(x, ...) {
 
 # Append a deferred op to the func's buffer. Each op is stored as a
 # `list(render, payload)` pair; the line is produced by `render(payload)` at
-# repr time (see func_lines()), once value ids can be numbered. The buffer is
-# a cons list, so appending is O(1) per op and never touches earlier ops.
+# repr time (see func_lines()), once value ids can be numbered. `ops` is grown
+# in place: because it lives in the `buf` environment and is not aliased between
+# emissions, `[[<-` extends it with amortised-O(1) doubling rather than copying.
 func_emit <- function(func, item) {
   buf <- func[["buf"]]
-  buf$n <- buf$n + 1L
-  buf$stack <- list(item, buf$stack)
+  n <- buf$n + 1L
+  buf$n <- n
+  buf$ops[[n]] <- item
 }
 
 # Rendered op lines of a Func, in emission order (`character()`). Rendering
@@ -156,19 +158,12 @@ func_lines <- function(func) {
     on.exit(pop_repr_ids(NULL), add = TRUE)
   }
   buf <- func[["buf"]]
+  ops <- buf$ops
   n <- buf$n
-  # The cons list is LIFO (head = last op); materialise in emission order.
-  items <- vector("list", n)
-  node <- buf$stack
-  i <- n
-  while (i > 0L) {
-    items[[i]] <- node[[1L]]
-    node <- node[[2L]]
-    i <- i - 1L
-  }
+  # `ops` is already in emission order (front-to-back).
   lines <- character(n)
   for (i in seq_len(n)) {
-    item <- items[[i]]
+    item <- ops[[i]]
     lines[[i]] <- item[[1L]](item[[2L]])
   }
   lines
@@ -186,12 +181,11 @@ collect_named_numeric <- function(func) {
       out <- c(out, as.numeric(id))
     }
   }
-  node <- func[["buf"]]$stack
-  while (!is.null(node)) {
-    for (cf in node[[1L]][[2L]]$funcs) {
+  buf <- func[["buf"]]
+  for (i in seq_len(buf$n)) {
+    for (cf in buf$ops[[i]][[2L]]$funcs) {
       out <- c(out, collect_named_numeric(cf))
     }
-    node <- node[[2L]]
   }
   out
 }
@@ -292,7 +286,7 @@ Func <- function(
   env$outputs <- outputs
   buf <- new.env(parent = emptyenv())
   buf$n <- 0L
-  buf$stack <- NULL
+  buf$ops <- list()
   env$buf <- buf
 
   # Return the environment directly with Func class


### PR DESCRIPTION
## Summary

Replaces the func's hand-rolled LIFO **cons-list** op buffer with a **`fastmap::fastqueue`** — a maintained mutable growable list with genuine amortised-O(1) append.

- `func_emit()` → `func[["buf"]]$add(item)`
- `func_lines()` → iterates `buf$as_list()` (already emission order — the LIFO reversal pass is gone)
- `collect_named_numeric()` → plain loop over `buf$as_list()` instead of a linked-list walk
- `fastmap` added to `Imports`

## Why not just grow an R list?

The obvious "simplification" — grow a list held in the func's `buf` field, `buf$ops[[n]] <- item` — is **not** O(1). An R list stored in a field is **copy-on-modify**: it gets duplicated on every append, degrading op emission to **O(n²)**. Measured on the real `func_emit`:

| n | µs/op (`buf$ops[[n]]<-`) |
|---|---|
| 2 000 | 18 |
| 4 000 | 34 |
| 8 000 | 59 |
| 16 000 | 118 |

Per-op cost doubles with n → quadratic. (An earlier revision of this PR did exactly that and regressed; the first commit is kept for history, the second supersedes it.)

`fastmap::fastqueue` is O(1) per append — verified flat at ~1.5 µs/op up to n=16k — so we neither hand-roll a cons list nor pay the O(n²) copy.

## No regression (lowering benchmark)

`benchmarks/lowering/lowering.R`, fastqueue vs the original cons list (median ms, ratio <1 = faster):

| graph | phase | size | cons | fastqueue | ratio |
|---|---|---|---|---|---|
| chain | build | 5000 | 617.4 | 490.4 | **0.79×** |
| chain | repr | 5000 | 242.8 | 241.4 | 0.99× |
| fan | build | 5000 | 941.2 | 834.1 | **0.89×** |
| fan | repr | 5000 | 608.3 | 415.7 | **0.68×** |
| fan | build | 200 | 48.2 | 56.6 | 1.17× (tiny graph, noise) |

**Geomean 0.914×** across all graph/phase/size cells — faster overall, and better-scaling at large n. The single >1 cell is the smallest graph (200 ops), within noise.

## Correctness

- IR output **byte-identical** (smoke test + full suite).
- Full suite: **280 tests / 956 assertions — 0 failures, 0 errors**, 3 skips.
- `air format` + `jarl check` clean.

Design note in `AGENTS.md` updated, including a warning about the O(n²) copy-on-modify trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)