### PR TITLE
ci: comment out self-hosted GPU runner job

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,13 +20,14 @@ jobs:
         config:
           - { os: "macos", r: "release", platform: "cpu" }
           - { os: "ubuntu", r: "release", platform: "cpu" }
-          - { os: "ubuntu", platform: "cuda"}
+          # Disabled: the self-hosted GPU runner is currently unavailable.
+          # - { os: "ubuntu", platform: "cuda"}
           - { os: "windows", r: "release", platform: "cpu"}
 
         include:
-          - config: {os: "ubuntu", platform: "cuda"}
-            container: {image: 'sebffischer/anvl-cuda-base:latest', options: '--gpus all --runtime=nvidia'}
-            runner: ['self-hosted', 'gpu']
+          # - config: {os: "ubuntu", platform: "cuda"}
+          #   container: {image: 'sebffischer/anvl-cuda-base:latest', options: '--gpus all --runtime=nvidia'}
+          #   runner: ['self-hosted', 'gpu']
           - config: {os: "ubuntu", platform: "cpu"}
             runner: 'ubuntu-latest'
           - config: {os: "macos", platform: "cpu"}


### PR DESCRIPTION
The custom GPU runner is currently unavailable, so the CUDA job is commented out rather than removed to make it easy to restore later.