### PR TITLE
refactor: follow tengen's ndims() -> naxes() rename

### DIFF
--- a/R/assert.R
+++ b/R/assert.R
@@ -126,17 +126,17 @@ assert_vt_has_ttype <- function(
   x,
   ...,
   shape = NULL,
-  ndims = NULL,
+  naxes = NULL,
   arg = rlang::caller_arg(x),
   call = rlang::caller_env()
 ) {
   dtypes <- list(...)
 
   # Fast path for the common success case: class-name dtypes, no
-  # shape/ndims constraint.
+  # shape/naxes constraint.
   if (
     is.null(shape) &&
-      is.null(ndims) &&
+      is.null(naxes) &&
       inherits(x, "ValueType") &&
       inherits(x$type, "TensorType")
   ) {
@@ -217,11 +217,11 @@ assert_vt_has_ttype <- function(
       call = call
     )
   }
-  if (!is.null(ndims) && ndims(tensor_type) != ndims) {
+  if (!is.null(naxes) && naxes(tensor_type) != naxes) {
     cli_abort(
       c(
-        "{.arg {arg}} must have {ndims} dimensions.",
-        x = "Got {length(shape(tensor_type))} dimensions."
+        "{.arg {arg}} must have {naxes} axes.",
+        x = "Got {length(shape(tensor_type))} axes."
       ),
       call = call
     )
@@ -256,7 +256,7 @@ assert_const <- function(
   x,
   dtype = NULL,
   shape = NULL,
-  ndims = NULL,
+  naxes = NULL,
   arg = rlang::caller_arg(x),
   call = rlang::caller_env()
 ) {
@@ -290,11 +290,11 @@ assert_const <- function(
       call = call
     )
   }
-  if (!is.null(ndims) && ndims(x$type) != ndims) {
+  if (!is.null(naxes) && naxes(x$type) != naxes) {
     cli_abort(
       c(
-        "{.arg {arg}} must have {ndims} dimensions.",
-        x = "Got {length(shape(x$type))} dimensions."
+        "{.arg {arg}} must have {naxes} axes.",
+        x = "Got {length(shape(x$type))} axes."
       ),
       call = call
     )

--- a/R/op-broadcast_in_dim.R
+++ b/R/op-broadcast_in_dim.R
@@ -11,7 +11,7 @@ infer_types_broadcast_in_dim <- function(
   shape
 ) {
   assert_vt_is_tensor(operand)
-  assert_const(broadcast_dimensions, dtype = "i64", ndims = 1L)
+  assert_const(broadcast_dimensions, dtype = "i64", naxes = 1L)
   assert_shapevec(shape)
 
   operand_dims <- shape(operand)

--- a/R/op-convolution.R
+++ b/R/op-convolution.R
@@ -193,11 +193,11 @@ infer_types_convolution <- function(
   }
   assert_class(precision_config, "PrecisionConfig")
   assert_vts_are_tensors(lhs, rhs)
-  assert_const(window_strides, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(padding, dtype = IntegerType(64L), ndims = 2L)
-  assert_const(lhs_dilation, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(rhs_dilation, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(window_reversal, dtype = BooleanType(), ndims = 1L)
+  assert_const(window_strides, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(padding, dtype = IntegerType(64L), naxes = 2L)
+  assert_const(lhs_dilation, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(rhs_dilation, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(window_reversal, dtype = BooleanType(), naxes = 1L)
   assert_const(feature_group_count, dtype = IntegerType(64L), shape = integer())
   assert_const(batch_group_count, dtype = IntegerType(64L), shape = integer())
 

--- a/R/op-reduce.R
+++ b/R/op-reduce.R
@@ -11,7 +11,7 @@ infer_types_reduce <- function(inputs, init_values, body, dimensions) {
 
   lapply(inputs, assert_vt_is_tensor)
   lapply(init_values, assert_vt_is_tensor)
-  assert_const(dimensions, dtype = IntegerType(64L), ndims = 1L)
+  assert_const(dimensions, dtype = IntegerType(64L), naxes = 1L)
   assert_func(body)
 
   # (C3)

--- a/R/op-reduce_window.R
+++ b/R/op-reduce_window.R
@@ -17,11 +17,11 @@ infer_types_reduce_window <- function(
 ) {
   assert_func(body)
   assert_vts_are_tensors(...)
-  assert_const(window_dimensions, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(window_strides, dtype = IntegerType(64L), ndims = 1)
-  assert_const(base_dilations, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(window_dilations, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(padding, dtype = IntegerType(64L), ndims = 2L)
+  assert_const(window_dimensions, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(window_strides, dtype = IntegerType(64L), naxes = 1)
+  assert_const(base_dilations, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(window_dilations, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(padding, dtype = IntegerType(64L), naxes = 2L)
 
   value_types <- list(...)
 

--- a/R/op-reverse.R
+++ b/R/op-reverse.R
@@ -10,7 +10,7 @@ infer_types_reverse <- function(
   dimensions
 ) {
   assert_vt_is_tensor(operand)
-  assert_const(dimensions, dtype = IntegerType(64L), ndims = 1L)
+  assert_const(dimensions, dtype = IntegerType(64L), naxes = 1L)
 
   operand_dims <- shape(operand)
   revdims <- dimensions$data

--- a/R/op-rng_bit_generator.R
+++ b/R/op-rng_bit_generator.R
@@ -31,7 +31,7 @@ infer_types_rng_bit_generator <- function(
   shape
 ) {
   assert_vt_is_tensor(initial_state)
-  assert_vt_has_ttype(initial_state, dtype = UIntegerType(64L), ndims = 1L)
+  assert_vt_has_ttype(initial_state, dtype = UIntegerType(64L), naxes = 1L)
 
   if (!test_choice(rng_algorithm, c("DEFAULT", "THREE_FRY", "PHILOX"))) {
     cli_abort(c(

--- a/R/op-scatter.R
+++ b/R/op-scatter.R
@@ -225,7 +225,7 @@ infer_types_scatter <- function(
     any(x < 0L) || any(x >= rank)
   }
 
-  update_rank <- ndims(updates[[1L]])
+  update_rank <- naxes(updates[[1L]])
   # (C8)
   if (any_outside_rank_range(update_window_dims, update_rank)) {
     error_index_out_of_bounds(

--- a/R/op-select.R
+++ b/R/op-select.R
@@ -28,7 +28,7 @@ infer_types_select <- function(
   assert_vt_has_ttype(pred, "BooleanType")
 
   # (C1)
-  if (ndims(pred) != 0 && !identical(shape(pred), shape(on_true))) {
+  if (naxes(pred) != 0 && !identical(shape(pred), shape(on_true))) {
     cli_abort(c(
       "rank of {.arg pred} must be 0 or equal to rank of {.arg on_true}",
       x = "Got shapes {shapevec_repr(shape(pred))} and {shapevec_repr(shape(on_true))}."

--- a/R/op-slice.R
+++ b/R/op-slice.R
@@ -12,9 +12,9 @@ infer_types_slice <- function(
   strides
 ) {
   assert_vt_is_tensor(operand)
-  assert_const(start_indices, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(limit_indices, dtype = IntegerType(64L), ndims = 1L)
-  assert_const(strides, dtype = IntegerType(64L), ndims = 1L)
+  assert_const(start_indices, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(limit_indices, dtype = IntegerType(64L), naxes = 1L)
+  assert_const(strides, dtype = IntegerType(64L), naxes = 1L)
 
   operand_rank <- length(shape(operand))
   start_idx <- start_indices$data

--- a/R/op-transpose.R
+++ b/R/op-transpose.R
@@ -10,7 +10,7 @@ infer_types_transpose <- function(
   permutation
 ) {
   assert_vt_is_tensor(operand)
-  assert_const(permutation, dtype = IntegerType(64L), ndims = 1L)
+  assert_const(permutation, dtype = IntegerType(64L), naxes = 1L)
 
   operand_dims <- shape(operand)
   num_dims <- length(operand_dims)

--- a/tests/testthat/_snaps/assert.md
+++ b/tests/testthat/_snaps/assert.md
@@ -28,29 +28,29 @@
 ---
 
     Code
-      assert_vt_has_ttype(scalar, ndims = 1L)
+      assert_vt_has_ttype(scalar, naxes = 1L)
     Condition
       Error:
-      ! `scalar` must have 1 dimensions.
-      x Got 0 dimensions.
+      ! `scalar` must have 1 axes.
+      x Got 0 axes.
 
 ---
 
     Code
-      assert_vt_has_ttype(vector, ndims = 2L)
+      assert_vt_has_ttype(vector, naxes = 2L)
     Condition
       Error:
-      ! `vector` must have 2 dimensions.
-      x Got 1 dimensions.
+      ! `vector` must have 2 axes.
+      x Got 1 axes.
 
 ---
 
     Code
-      assert_vt_has_ttype(matrix, ndims = 1L)
+      assert_vt_has_ttype(matrix, naxes = 1L)
     Condition
       Error:
-      ! `matrix` must have 1 dimensions.
-      x Got 2 dimensions.
+      ! `matrix` must have 1 axes.
+      x Got 2 axes.
 
 # assert_vt_is_tensor
 

--- a/tests/testthat/test-assert.R
+++ b/tests/testthat/test-assert.R
@@ -24,36 +24,36 @@ test_that("assert_vt_has_ttype", {
     error = TRUE
   )
 
-  # Test with ndims argument
+  # Test with naxes argument
   scalar <- make_vt("f32", integer())
   vector <- make_vt("f32", 3L)
   matrix <- make_vt("f32", c(2L, 3L))
 
-  # Should pass when ndims matches
+  # Should pass when naxes matches
   expect_error(
-    assert_vt_has_ttype(scalar, ndims = 0L),
+    assert_vt_has_ttype(scalar, naxes = 0L),
     NA
   )
   expect_error(
-    assert_vt_has_ttype(vector, ndims = 1L),
+    assert_vt_has_ttype(vector, naxes = 1L),
     NA
   )
   expect_error(
-    assert_vt_has_ttype(matrix, ndims = 2L),
+    assert_vt_has_ttype(matrix, naxes = 2L),
     NA
   )
 
-  # Should fail when ndims doesn't match
+  # Should fail when naxes doesn't match
   expect_snapshot(
-    assert_vt_has_ttype(scalar, ndims = 1L),
+    assert_vt_has_ttype(scalar, naxes = 1L),
     error = TRUE
   )
   expect_snapshot(
-    assert_vt_has_ttype(vector, ndims = 2L),
+    assert_vt_has_ttype(vector, naxes = 2L),
     error = TRUE
   )
   expect_snapshot(
-    assert_vt_has_ttype(matrix, ndims = 1L),
+    assert_vt_has_ttype(matrix, naxes = 1L),
     error = TRUE
   )
 })


### PR DESCRIPTION
Updates the call sites of the renamed tengen generic and renames the matching `ndims` argument of the internal `assert_const()` / `assert_vt_has_ttype()` helpers, whose messages now speak of axes.

The StableHLO spec names (`dimensions`, `offset_dims`, `index_vector_dim`, ...) are unchanged.